### PR TITLE
Implement a dead code elimination friendly strategy

### DIFF
--- a/test/fixtures/else/disabled/expected.js
+++ b/test/fixtures/else/disabled/expected.js
@@ -6,4 +6,8 @@ var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
 
-'disabled';
+if (false) {
+  'enabled';
+} else {
+  'disabled';
+}

--- a/test/fixtures/else/enabled/expected.js
+++ b/test/fixtures/else/enabled/expected.js
@@ -6,4 +6,8 @@ var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
 
-'enabled';
+if (true) {
+  'enabled';
+} else {
+  'disabled';
+}

--- a/test/fixtures/if/disabled/expected.js
+++ b/test/fixtures/if/disabled/expected.js
@@ -5,3 +5,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'd
 var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
+
+if (false) {
+  'enabled';
+}

--- a/test/fixtures/if/enabled/expected.js
+++ b/test/fixtures/if/enabled/expected.js
@@ -6,4 +6,6 @@ var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
 
-'enabled';
+if (true) {
+  'enabled';
+}

--- a/test/fixtures/nested/disabled-disabled/expected.js
+++ b/test/fixtures/nested/disabled-disabled/expected.js
@@ -5,3 +5,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'd
 var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
+
+if (false) {
+  'a';
+  if (false) {
+    'b';
+  }
+  'c';
+}

--- a/test/fixtures/nested/disabled-dynamic/expected.js
+++ b/test/fixtures/nested/disabled-dynamic/expected.js
@@ -5,3 +5,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'd
 var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
+
+if (false) {
+  'a';
+  if ((0, _features2['default'])('dynamic')) {
+    'b';
+  }
+  'c';
+}

--- a/test/fixtures/nested/disabled-enabled/expected.js
+++ b/test/fixtures/nested/disabled-enabled/expected.js
@@ -5,3 +5,11 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'd
 var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
+
+if (false) {
+  'a';
+  if (true) {
+    'b';
+  }
+  'c';
+}

--- a/test/fixtures/nested/dynamic-disabled/expected.js
+++ b/test/fixtures/nested/dynamic-disabled/expected.js
@@ -8,6 +8,8 @@ var _features2 = _interopRequireDefault(_features);
 
 if ((0, _features2['default'])('dynamic')) {
   'a';
-
+  if (false) {
+    'b';
+  }
   'c';
 }

--- a/test/fixtures/nested/dynamic-enabled/expected.js
+++ b/test/fixtures/nested/dynamic-enabled/expected.js
@@ -8,8 +8,8 @@ var _features2 = _interopRequireDefault(_features);
 
 if ((0, _features2['default'])('dynamic')) {
   'a';
-
-  'b';
-
+  if (true) {
+    'b';
+  }
   'c';
 }

--- a/test/fixtures/nested/enabled-disabled/expected.js
+++ b/test/fixtures/nested/enabled-disabled/expected.js
@@ -6,6 +6,10 @@ var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
 
-'a';
-
-'c';
+if (true) {
+  'a';
+  if (false) {
+    'b';
+  }
+  'c';
+}

--- a/test/fixtures/nested/enabled-dynamic/expected.js
+++ b/test/fixtures/nested/enabled-dynamic/expected.js
@@ -6,8 +6,10 @@ var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
 
-'a';
-if ((0, _features2['default'])('dynamic')) {
-  'b';
+if (true) {
+  'a';
+  if ((0, _features2['default'])('dynamic')) {
+    'b';
+  }
+  'c';
 }
-'c';

--- a/test/fixtures/nested/enabled-enabled/expected.js
+++ b/test/fixtures/nested/enabled-enabled/expected.js
@@ -6,8 +6,10 @@ var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
 
-'a';
-
-'b';
-
-'c';
+if (true) {
+  'a';
+  if (true) {
+    'b';
+  }
+  'c';
+}

--- a/test/fixtures/not-if/disabled/expected.js
+++ b/test/fixtures/not-if/disabled/expected.js
@@ -6,4 +6,6 @@ var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
 
-'disabled';
+if (!false) {
+  'disabled';
+}

--- a/test/fixtures/not-if/enabled/expected.js
+++ b/test/fixtures/not-if/enabled/expected.js
@@ -5,3 +5,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'd
 var _features = require('features');
 
 var _features2 = _interopRequireDefault(_features);
+
+if (!true) {
+  'disabled';
+}

--- a/test/fixtures/preserves-other-imports/expected.js
+++ b/test/fixtures/preserves-other-imports/expected.js
@@ -10,6 +10,8 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : { 'default': obj };
 }
 
-'enabled';
+if (true) {
+  'enabled';
+}
 
 _features.FEATURES;

--- a/test/fixtures/ternary/disabled/expected.js
+++ b/test/fixtures/ternary/disabled/expected.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _features = require('features');
+
+var _features2 = _interopRequireDefault(_features);
+
+var x = false ? 'enabled' : 'disabled';

--- a/test/fixtures/ternary/disabled/fixture.js
+++ b/test/fixtures/ternary/disabled/fixture.js
@@ -1,0 +1,3 @@
+import isEnabled from 'features';
+
+var x = isEnabled('disabled') ? 'enabled' : 'disabled';

--- a/test/fixtures/ternary/dynamic/expected.js
+++ b/test/fixtures/ternary/dynamic/expected.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _features = require('features');
+
+var _features2 = _interopRequireDefault(_features);
+
+var x = (0, _features2['default'])('dynamic') ? 'enabled' : 'disabled';

--- a/test/fixtures/ternary/dynamic/fixture.js
+++ b/test/fixtures/ternary/dynamic/fixture.js
@@ -1,0 +1,3 @@
+import isEnabled from 'features';
+
+var x = isEnabled('dynamic') ? 'enabled' : 'disabled';

--- a/test/fixtures/ternary/enabled/expected.js
+++ b/test/fixtures/ternary/enabled/expected.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _features = require('features');
+
+var _features2 = _interopRequireDefault(_features);
+
+var x = true ? 'enabled' : 'disabled';

--- a/test/fixtures/ternary/enabled/fixture.js
+++ b/test/fixtures/ternary/enabled/fixture.js
@@ -1,0 +1,3 @@
+import isEnabled from 'features';
+
+var x = isEnabled('enabled') ? 'enabled' : 'disabled';

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,9 @@ describe('babel-plugin-feature-flags', function() {
   testFixture('not-if/enabled', options);
   testFixture('not-if/disabled', options);
   testFixture('not-if/dynamic', options);
+  testFixture('ternary/enabled', options);
+  testFixture('ternary/disabled', options);
+  testFixture('ternary/dynamic', options);
   testFixture('nested/enabled-enabled', options);
   testFixture('nested/enabled-disabled', options);
   testFixture('nested/enabled-dynamic', options);


### PR DESCRIPTION
Instead of special casing `if` statements, feature flag call expressions
are now simply replaced by true or false literals when possible. This
lets you use feature flagging in more expressive ways by leaning on dead
code eliminiation in tools like Uglify. For example, now you can do

```js
if (isEnabled('foo') || isEnabled('bar')) {
  // Uglify will be able to remove this code if both features are disabled
}
```

cc @mixonic @rwjblue @krisselden