### PR TITLE
Enable caching based on options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var stringify = require('json-stable-stringify');
+
 module.exports = function(options) {
   options = options || {};
   options.features = options.features || {};
@@ -24,7 +26,7 @@ module.exports = function(options) {
     }
   });
 
-  return function(babel) {
+  function babelPluginFeatureFlags(babel) {
     var t = babel.types;
 
     return new babel.Transformer('babel-plugin-feature-flags', {
@@ -44,7 +46,17 @@ module.exports = function(options) {
         }
       }
     });
+  }
+
+  babelPluginFeatureFlags.baseDir = function() {
+    return __dirname;
   };
+
+  babelPluginFeatureFlags.cacheKey = function() {
+    return stringify(options);
+  };
+
+  return babelPluginFeatureFlags;
 };
 
 function getFeatureName(callExpression) {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "devDependencies": {
     "babel-core": "^5.5.3",
     "mocha": "^2.2.5"
+  },
+  "dependencies": {
+    "json-stable-stringify": "^1.0.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -28,7 +28,7 @@ describe('babel-plugin-feature-flags', function() {
       disabled: 'disabled',
       dynamic: 'dynamic'
     }
-  }
+  };
 
   testFixture('if/enabled', options);
   testFixture('if/disabled', options);
@@ -52,4 +52,40 @@ describe('babel-plugin-feature-flags', function() {
   testFixture('nested/dynamic-disabled', options);
   testFixture('nested/dynamic-dynamic', options);
   testFixture('preserves-other-imports', options);
+
+  it('provides a baseDir', function() {
+    var expectedPath = path.join(__dirname, '..');
+
+    var featureFlagInstance = applyFeatureFlags({
+      import: {
+        module: 'features'
+      }
+    });
+
+    assert.equal(featureFlagInstance.baseDir(), expectedPath);
+  });
+
+  it('includes options in `cacheKey`', function() {
+    var first = applyFeatureFlags({
+      import: {
+        module: 'features'
+      },
+      features: {
+        foo: 'enabled',
+        bar: 'disabled'
+      }
+    });
+
+    var second = applyFeatureFlags({
+      import: {
+        module: 'features'
+      },
+      features: {
+        foo: 'enabled',
+        bar: 'dynamic'
+      }
+    });
+
+    assert.notEqual(first.cacheKey(), second.cacheKey());
+  });
 });


### PR DESCRIPTION
This goes along with https://github.com/babel/broccoli-babel-transpiler/pull/89.

See additional related PR's:

* https://github.com/babel/broccoli-babel-transpiler/pull/89
* https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/pull/34
* https://github.com/ember-cli/babel-plugin-htmlbars-inline-precompile/pull/15
* https://github.com/ember-cli/babel-plugin-filter-imports/pull/10
* https://github.com/ember-cli/ember-cli-htmlbars/pull/90
* https://github.com/offirgolan/ember-cp-validations/pull/305

Note: this PR is against a new v0.2.x branch created.  Once we move to babel 6 here, this code is no longer needed because the default babel 6 options passing mechanism "just works" for us.